### PR TITLE
add gem install io-console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache \
     jq
 
 ADD entrypoint.sh /entrypoint.sh
+RUN gem install io-console
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Downgrading the image also needed this gem to be installed. I put it here, but you probably will figure out it fits better in the docker image.

Anyway with this change I could upload my package https://forge.puppet.com/modules/Enucatl/i2pd